### PR TITLE
Fixed blog description spelling of "official"

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitepress'
 
 export default defineConfig({
   title: 'The Vue Point',
-  description: 'The offical blog for the Vue.js project',
+  description: 'The official blog for the Vue.js project',
   head: [
     ['meta', { name: 'twitter:site', content: '@vuejs' }],
     ['meta', { name: 'twitter:card', content: 'summary' }],


### PR DESCRIPTION
The official Vue docs spells "official" as "offical" in its description.